### PR TITLE
Fix README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install pdfplumber tqdm argparse
 ## Usage
 You can run the script using the following command:
 ```bash
-python PDFtoText_improved.py <pdf_directory> <txt_directory> [-o] [-p <password>]
+python PDFtoText.py <pdf_directory> <txt_directory> [-o] [-p <password>]
 ```
 - `<pdf_directory>`: The directory containing the PDF files.
 - `<txt_directory>`: The directory where the text files will be saved.


### PR DESCRIPTION
## Summary
- fix README to point to the actual `PDFtoText.py` script

## Testing
- `python -m py_compile PDFtoText.py`


------
https://chatgpt.com/codex/tasks/task_e_685cf499268c8327921a3f7f29d45a0e